### PR TITLE
Reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,14 @@
     "webpack",
     "rollup"
   ],
+  "files": [
+    "src",
+    "LICENSE",
+    "CHANGELOG.md",
+    "README.md",
+    "rollup.js",
+    "webpack.js"
+  ],
   "dependencies": {
     "babylon": "^6.18.0",
     "@babel/traverse": "7.22.8",


### PR DESCRIPTION
### What does this PR do?

I defined a `files` prop in the `package.json` to avoid publishing a lot of unnecessary things.

Before:

```bash
npm notice === Tarball Details ===
npm notice name:          svelte-extend
npm notice version:       5.0.1
npm notice filename:      svelte-extend-5.0.1.tgz
npm notice package size:  161.2 kB
npm notice unpacked size: 632.9 kB
npm notice shasum:        2adec2599603e49213cb778c7b6ea5c9181d8bfc
npm notice integrity:     sha512-jSHzBdzLYwHQk[...]HfRy9JSlWYMbg==
npm notice total files:   74
```

After:

```bash
npm notice === Tarball Details ===
npm notice name:          svelte-extend
npm notice version:       5.0.1
npm notice filename:      svelte-extend-5.0.1.tgz
npm notice package size:  17.8 kB
npm notice unpacked size: 73.3 kB
npm notice shasum:        deeb5d2cd2cf9e02d033caf05c8aa10ff88e0f25
npm notice integrity:     sha512-CT5/qF86SK9XB[...]zZezwmLUphGdg==
npm notice total files:   16
```

### How should it be tested manually?

```bash
npm test
```
